### PR TITLE
Support time range to query dimension names/values

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -51,6 +51,14 @@ function (angular, _, moment, sdk, dateMath, kbn) {
     self = this;
   }
 
+  MonascaDatasource.prototype.timeRange = function() {
+    var timeRange = angular.element('grafana-app').injector().get('timeSrv').timeRange();
+    return {
+      start_time: this.translateTime(timeRange.from),
+      end_time: this.translateTime(timeRange.to),
+    };
+  };
+
   MonascaDatasource.prototype.query = function(options) {
     var datasource = this;
     var from =  this.translateTime(options.range.from);
@@ -110,6 +118,7 @@ function (angular, _, moment, sdk, dateMath, kbn) {
   MonascaDatasource.prototype.dimensionNamesQuery = function(params) {
     var datasource = this;
     var url = this.url_version + '/metrics/dimensions/names';
+    params = Object.assign(params, this.timeRange())
     return this._limitedMonascaRequest(url, params, false).then(function(data) {
       return datasource.convertDataList(data, 'dimension_name');
     }).catch(function(err) {throw err;});
@@ -118,6 +127,7 @@ function (angular, _, moment, sdk, dateMath, kbn) {
   MonascaDatasource.prototype.dimensionValuesQuery = function(params) {
     var datasource = this;
     var url = this.url_version + '/metrics/dimensions/names/values';
+    params = Object.assign(params, this.timeRange())
     return this._limitedMonascaRequest(url, params, false).then(function(data) {
       return datasource.convertDataList(data, 'dimension_value');
     }).catch(function(err) {throw err;});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monasca-grafana-datasource",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Grafana datasource for use with OpenStack Monasca API",
   "main": "datasource.js",
   "directories": {

--- a/plugin.json
+++ b/plugin.json
@@ -26,7 +26,7 @@
       {"name": "GitHub", "url": "https://github.com/openstack/monasca-grafana-datasource"},
       {"name": "License", "url": "https://github.com/openstack/monasca-grafana-datasource/LICENSE"}
     ],
-    "version": "1.2.1",
+    "version": "1.3.0",
     "updated": "2017-10-23"
   },
 


### PR DESCRIPTION
At present, dimensions are not scoped by time window, which makes
dimension related queries to large databases timeout because it searches
all of time instead of a time window specified on the grafana app.

This commit implements the client side changes to address issue by
scoping the search to time range specified on the app. It also bumps up
the plugin version to 1.3.0 since it is a minor backward compatible API
change.

Depends-On: https://review.opendev.org/#/c/670318
Change-Id: I13614595707697552119926273f06967b8d49b1d
Story: 2006204
Task: 35789
(cherry picked from commit 76885b6433df66f630327b3517856bab87dc0868)